### PR TITLE
Minor struct loading bugfixes and loading optimizations.

### DIFF
--- a/FFXIVMonReborn/ExdDataCache.cs
+++ b/FFXIVMonReborn/ExdDataCache.cs
@@ -15,7 +15,7 @@ namespace FFXIVMonReborn
 
         public ExdDataCache(string gamePath)
         {
-            GameData data = new GameData(gamePath);
+            GameData data = new GameData(gamePath, new LuminaOptions {PanicOnSheetChecksumMismatch = false});
             _bnpcNames = data.Excel.GetSheet<BNpcName>().ToDictionary(row => row.RowId, row => row.Singular.ToString());
             _placeNames = data.Excel.GetSheet<PlaceName>().ToDictionary(row => row.RowId, row => row.Name.ToString());
             _actionNames = data.Excel.GetSheet<Action>().ToDictionary(row => row.RowId, row => row.Name.ToString());

--- a/FFXIVMonReborn/FFXIVMonReborn.csproj
+++ b/FFXIVMonReborn/FFXIVMonReborn.csproj
@@ -66,10 +66,10 @@
     <WriteCodeFragment Language="C#" OutputFile="$(CustomAssemblyInfoFile)" AssemblyAttributes="@(AssemblyAttributes)" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.2.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />
     <PackageReference Include="IndexRange" Version="1.0.1-beta.1" />
-    <PackageReference Include="Lumina" Version="3.5.1" />
-    <PackageReference Include="Lumina.Excel" Version="6.0.2" />
+    <PackageReference Include="Lumina" Version="3.10.0" />
+    <PackageReference Include="Lumina.Excel" Version="6.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FFXIVMonReborn/Util.cs
+++ b/FFXIVMonReborn/Util.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Dynamic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualBasic.ApplicationServices;
 
 namespace FFXIVMonReborn
 {
@@ -103,10 +100,10 @@ namespace FFXIVMonReborn
 
         public static byte[] StringToByteArray(String hex)
         {
-            int NumberChars = hex.Length;
-            byte[] bytes = new byte[NumberChars / 2];
-            for (int i = 0; i < NumberChars; i += 2)
-                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            int numberChars = hex.Length;
+            byte[] bytes = new byte[numberChars / 2];
+            for (int i = 0; i < numberChars; i += 2)
+                byte.TryParse(hex.AsSpan(i, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out bytes[i / 2]);
             return bytes;
         }
 

--- a/FFXIVMonReborn/Views/LogView.xaml
+++ b/FFXIVMonReborn/Views/LogView.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:FFXIVMonReborn"
         mc:Ignorable="d"
-        Title="Log" Width="719.823" Height="283.202" Closing="ScriptDebugView_OnClosing">
+        Title="Log" Width="719.823" Height="283.202" Closing="ScriptDebugView_OnClosing" IsVisibleChanged="LogView_OnIsVisibleChanged">
     <Grid>
         <RichTextBox FontFamily="Consolas" VerticalScrollBarVisibility="Visible" IsReadOnly="True" x:Name="InfoBox">
             <RichTextBox.Resources>

--- a/FFXIVMonReborn/Views/LogView.xaml.cs
+++ b/FFXIVMonReborn/Views/LogView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
+using System.Windows.Documents;
 
 namespace FFXIVMonReborn
 {
@@ -20,17 +21,30 @@ namespace FFXIVMonReborn
 
         public void WriteLine(string line)
         {
-            string text = $"{line}\n";
-            InfoBox.AppendText(text);
-            Debug.WriteLine(text);
+            /*Concatenating line endings for the InfoBox.AppendText caused memory consumption and CPU usage to skyrocket
+             during Struct parsing thanks to the constant creation of new Strings.
+             Given how AppendText does this behind the scenes anyway, this was preferable to a StringBuilder.*/
+            InfoBox.Document.Blocks.Add(new Paragraph(new Run(line)));
+            Debug.WriteLine(line + "\n");
 
-            InfoBox.ScrollToEnd();
+            /*Unconditionally calling ScrollToEnd causes significant slowdown on AddPacketToListView, thanks to ScrollToEnd
+             calling UpdateLayout() regardless of visibility, recreating the layout of the RichTextBox on every state change, 
+             which happened to be every Packet addition.*/
+            if(IsVisible)
+                InfoBox.ScrollToEnd();
         }
 
         private void ScriptDebugView_OnClosing(object sender, CancelEventArgs e)
         {
             e.Cancel = true;
             this.Visibility = Visibility.Hidden;
+        }
+
+        private void LogView_OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            //e.NewValue is the new this.IsVisible
+            if ((bool) e.NewValue)
+                InfoBox.ScrollToEnd();
         }
     }
 }

--- a/FFXIVMonReborn/Views/XivMonTab.xaml.cs
+++ b/FFXIVMonReborn/Views/XivMonTab.xaml.cs
@@ -15,7 +15,6 @@ using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MessageBox = System.Windows.MessageBox;
 using UserControl = System.Windows.Controls.UserControl;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows.Media;
 using FFXIVMonReborn.DataModel;
@@ -28,9 +27,6 @@ using Brushes = System.Windows.Media.Brushes;
 using Capture = FFXIVMonReborn.DataModel.Capture;
 using Color = System.Windows.Media.Color;
 using FFXIVMonReborn.Database.GitHub;
-using Newtonsoft.Json.Bson;
-using System.Text.Unicode;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace FFXIVMonReborn.Views
@@ -458,7 +454,7 @@ namespace FFXIVMonReborn.Views
                 foreach (var entry in structEntries.Item1)
                 {
                     if (entry.isArrayDeclaration)
-                        lastArrayColor = Struct.TypeColours[entry.DataTypeCol];
+                        Struct.TypeColours.TryGetValue(entry.DataTypeCol, out lastArrayColor);
                     else if (entry.isArrayElement && entry.DataTypeCol == null)
                         color = lastArrayColor;
                     else if (!Struct.TypeColours.TryGetValue(entry.DataTypeCol, out color))


### PR DESCRIPTION
This PR:

- Fixes a KeyNotFoundException on applying structs with arrays of custom types, which broke struct parsing on Spawn and Status packets and probably many more
- Fixes a IndexOutOfRangeException on applying structs with nested structs (PlayerList, HateRank, HateList and probably a few other packets).
- Optimize string manipulation on the LoadCapture path, this change massively speeds up loading big captures and struct parsing by avoiding string manipulation on loops (Strings are immutable on C#).