### PR TITLE
Update ffxivmon to support Retail 6.40

### DIFF
--- a/FFXIVMonReborn/FFXIVMonReborn.csproj
+++ b/FFXIVMonReborn/FFXIVMonReborn.csproj
@@ -68,8 +68,8 @@
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />
     <PackageReference Include="IndexRange" Version="1.0.1-beta.1" />
-    <PackageReference Include="Lumina" Version="3.10.0" />
-    <PackageReference Include="Lumina.Excel" Version="6.3.2" />
+    <PackageReference Include="Lumina" Version="3.10.2" />
+    <PackageReference Include="Lumina.Excel" Version="6.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
New major Retail patch, new ffxivmon bump, in order to add out of the box support for the latest Retail patch, this PR:
1. Updates Lumina and Lumina.Excel in order to support the 6.40 sheets
2. Updates Machina to it's latest version in order to fix FFXIV-As-Oodle provider with the 6.40 client.

