### PR TITLE
Add support for capturing using Deucalion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/Machina"]
 	path = lib/Machina
-	url = https://github.com/lmcintyre/machina
+	url = https://github.com/MapleHinata/machina

--- a/FFXIVMonReborn/App.config
+++ b/FFXIVMonReborn/App.config
@@ -61,6 +61,9 @@
             <setting name="OodleLibraryPath" serializeAs="String">
                 <value />
             </setting>
+            <setting name="UseDeucalion" serializeAs="String">
+                <value>False</value>
+            </setting>
         </FFXIVMonReborn.Properties.Settings>
     </userSettings>
 </configuration>

--- a/FFXIVMonReborn/MachinaCaptureWorker.cs
+++ b/FFXIVMonReborn/MachinaCaptureWorker.cs
@@ -1,20 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Threading;
 using FFXIVMonReborn.DataModel;
 using FFXIVMonReborn.Properties;
 using FFXIVMonReborn.Views;
-using Machina;
 using Machina.FFXIV;
 using Machina.FFXIV.Headers;
 using Machina.FFXIV.Oodle;
@@ -150,7 +142,18 @@ namespace FFXIVMonReborn
             monitor.MessageSentEventHandler = MessageSent;
 
             monitor.OodleImplementation = _oodleImplementation;
+            monitor.UseDeucalion = Settings.Default.UseDeucalion;
 
+            if (monitor.UseDeucalion)
+            {
+                int? id = Process.GetProcessesByName("ffxiv_dx11").FirstOrDefault()?.Id;
+                
+                if (id == null)
+                    throw new ThreadStateException("No ffxiv_dx11.exe process was found, please ensure that the DirectX 11 version of the game is running and try again.");
+                
+                monitor.ProcessID = (uint)id;
+            }
+            
             // GamePath points to sqpack
             monitor.OodlePath = GetOodlePath();
 

--- a/FFXIVMonReborn/Properties/Settings.Designer.cs
+++ b/FFXIVMonReborn/Properties/Settings.Designer.cs
@@ -240,5 +240,17 @@ namespace FFXIVMonReborn.Properties {
                 this["OodleLibraryPath"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UseDeucalion {
+            get {
+                return ((bool)(this["UseDeucalion"]));
+            }
+            set {
+                this["UseDeucalion"] = value;
+            }
+        }
     }
 }

--- a/FFXIVMonReborn/Properties/Settings.settings
+++ b/FFXIVMonReborn/Properties/Settings.settings
@@ -52,5 +52,8 @@
     </Setting>
     <Setting Name="OodleLibraryPath" Type="System.String" Scope="User">
     </Setting>
+    <Setting Name="UseDeucalion" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIVMonReborn/Views/MainWindow.xaml
+++ b/FFXIVMonReborn/Views/MainWindow.xaml
@@ -92,6 +92,7 @@
                     <Separator></Separator>
                     <MenuItem x:Name="SwitchModeSockets" Header="_Capture mode: Sockets" Click="SwitchModeSockets_OnClick"/>
                     <MenuItem x:Name="SwitchModePcap" Header="_Capture mode: WinPCap" Click="SwitchModePcap_OnClick"/>
+                    <MenuItem x:Name="SwitchModeDeucalion" Header="_Inject the Deucalion library for Capture" IsCheckable="True" Click="SwitchModeDeucalion_OnClick" Checked="SwitchModeDeucalion_OnChecked" Unchecked="SwitchModeDeucalion_OnUnchecked"/>
                     <Separator></Separator>
                     <MenuItem Header="_About" Click="AboutButton_OnClick"/>
                 </MenuItem>

--- a/FFXIVMonReborn/Views/MainWindow.xaml.cs
+++ b/FFXIVMonReborn/Views/MainWindow.xaml.cs
@@ -145,6 +145,11 @@ namespace FFXIVMonReborn.Views
 
             if (Properties.Settings.Default.OodleEnforced)
                 OodleEnforcedCheckbox.IsChecked = true;
+
+            if (Properties.Settings.Default.UseDeucalion)
+            {
+                SwitchModeDeucalion.IsChecked = true;
+            }
             
             OodleImplementation = (OodleImplementation) Settings.Default.OodleImplementation;
             OodleImplementationItems = new ObservableCollection<OodleImplementationItem>();
@@ -811,6 +816,42 @@ namespace FFXIVMonReborn.Views
                 Settings.Default.Save();
                 
             }
+        }
+        
+        private void SwitchModeDeucalion_OnChecked(object sender, RoutedEventArgs e)
+        {
+            if (AreTabsCapturing())
+            {
+                MessageBox.Show("A capture is in progress.", "Error", MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                return;
+            }
+            
+            Settings.Default.UseDeucalion = true;
+            Settings.Default.Save();
+        }
+
+        private void SwitchModeDeucalion_OnUnchecked(object sender, RoutedEventArgs e)
+        {
+            if (AreTabsCapturing())
+            {
+                MessageBox.Show("A capture is in progress.", "Error", MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                return;
+            }
+            
+            Settings.Default.UseDeucalion = false;
+            Settings.Default.Save();
+        }
+
+        private void SwitchModeDeucalion_OnClick(object sender, RoutedEventArgs e)
+        {
+            if (Settings.Default.UseDeucalion)
+                MessageBox.Show("Deucalion allows you to capture packets by injecting a DLL into the game, " +
+                                "skipping network capturing and Oodle. " +
+                                "However, Deucalion might not work with all game versions.", 
+                    "FFXIVMon Reborn", MessageBoxButton.OK,
+                    MessageBoxImage.Information);
         }
     }
 


### PR DESCRIPTION
Self explanatory, uses the DeucalionClient present in Machina as a shim for the [Deucalion](https://github.com/ff14wed/deucalion) library, allowing for decompressed packet captures by hooking into the game client, bypassing Oodle.

This is desirable, as since the move to Oodle TCP, retail captures need to be done from connection epoch, as Oodle TCP uses TCP state history for dictionary training.